### PR TITLE
Fix bug on calculating SIGJSON on not using useJSON flag

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -102,7 +102,9 @@ func NewKeepalivedCollector(useJSON, ping bool, pidPath string) *KeepalivedColle
 		"keepalived_script_state":        prometheus.NewDesc("keepalived_script_state", "Tracker Script State", []string{"name"}, nil),
 	}
 
-	kc.SIGJSON = sigNum("JSON")
+	if kc.useJSON {
+		kc.SIGJSON = sigNum("JSON")
+	}
 	kc.SIGDATA = sigNum("DATA")
 	kc.SIGSTATS = sigNum("STATS")
 


### PR DESCRIPTION
signum signal for SIGJSON sends to Keepalived on not using useJSON flag so if Keepalived doesn't support SIGJSON, Keepalived Exporter will be panic!