### PR TITLE
Fix bug on stuck for Keepalived signal response

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,7 @@ golang.org/x/sys v0.0.0-20191220142924-d4481acd189f h1:68K/z8GLUxV76xGSqwTWw2gyk
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 h1:JA8d3MPx/IToSyXZG/RhwYEtfrKO1Fxrqe8KrkiLXKM=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -13,13 +13,15 @@ import (
 // KeepalivedCollector implements prometheus.Collector interface and stores required info to collect data
 type KeepalivedCollector struct {
 	sync.Mutex
-	useJSON  bool
-	ping     bool
-	pidPath  string
-	SIGDATA  int
-	SIGJSON  int
-	SIGSTATS int
-	metrics  map[string]*prometheus.Desc
+	runningSignal     bool
+	failedStatsSignal bool
+	useJSON           bool
+	ping              bool
+	pidPath           string
+	SIGDATA           int
+	SIGJSON           int
+	SIGSTATS          int
+	metrics           map[string]*prometheus.Desc
 }
 
 // VRRPStats represents Keepalived stats about VRRP
@@ -73,9 +75,11 @@ type KeepalivedStats struct {
 // NewKeepalivedCollector is creating new instance of KeepalivedCollector
 func NewKeepalivedCollector(useJSON, ping bool, pidPath string) *KeepalivedCollector {
 	kc := &KeepalivedCollector{
-		useJSON: useJSON,
-		ping:    ping,
-		pidPath: pidPath,
+		useJSON:           useJSON,
+		ping:              ping,
+		pidPath:           pidPath,
+		runningSignal:     false,
+		failedStatsSignal: false,
 	}
 
 	commonLabels := []string{"iname", "intf", "vrid", "state"}

--- a/internal/collector/parser.go
+++ b/internal/collector/parser.go
@@ -56,11 +56,7 @@ func (VRRPData) getIntState(state string) (int, bool) {
 }
 
 func (k *KeepalivedCollector) jsonVrrps() ([]VRRP, error) {
-	err := k.signal(k.SIGJSON)
-	if err != nil {
-		logrus.Error("Failed to send JSON signal to keepalived: ", err)
-		return nil, err
-	}
+	k.signalHandler(k.SIGJSON)
 
 	f, err := os.Open("/tmp/keepalived.json")
 	if err != nil {
@@ -79,11 +75,8 @@ func (k *KeepalivedCollector) jsonVrrps() ([]VRRP, error) {
 }
 
 func (k *KeepalivedCollector) statsVrrps() ([]VRRPStats, error) {
-	err := k.signal(k.SIGSTATS)
-	if err != nil {
-		logrus.Error("Failed to send STATS signal to keepalived: ", err)
-		return nil, err
-	}
+	k.signalHandler(k.SIGSTATS)
+
 	f, err := os.Open("/tmp/keepalived.stats")
 	if err != nil {
 		logrus.Error("Failed to open /tmp/keepalived.stats: ", err)
@@ -100,10 +93,8 @@ func (k *KeepalivedCollector) statsVrrps() ([]VRRPStats, error) {
 }
 
 func (k *KeepalivedCollector) dataVrrps() ([]VRRPData, error) {
-	err := k.signal(k.SIGDATA)
-	if err != nil {
-		logrus.Error("Failed to send DATA signal to keepalived: ", err)
-		return nil, err
+	if !k.failedStatsSignal {
+		k.signalHandler(k.SIGDATA)
 	}
 
 	f, err := os.Open("/tmp/keepalived.data")

--- a/internal/collector/signal.go
+++ b/internal/collector/signal.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -57,4 +58,35 @@ func (k *KeepalivedCollector) signal(signal int) error {
 	// Wait 10ms for Keepalived to create its files
 	time.Sleep(10 * time.Millisecond)
 	return nil
+}
+
+func (k *KeepalivedCollector) signalHandler(signum int) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	finishedSignal := make(chan bool)
+	defer cancel()
+
+	if !k.runningSignal {
+		k.runningSignal = true
+		go func() {
+			err := k.signal(signum)
+			if err != nil {
+				logrus.WithField("SigNum", signum).Error("Failed to send signal to keepalived: ", err)
+			}
+			k.runningSignal = false
+			finishedSignal <- true
+		}()
+	}
+
+	select {
+	case <-ctx.Done():
+		logrus.WithField("SigNum", signum).Warn("Failed get response from signal less than 1 seconds")
+		if signum == k.SIGSTATS {
+			k.failedStatsSignal = true
+		}
+	case <-finishedSignal:
+		logrus.WithField("SigNum", signum).Info("Signal process finished successfully")
+		if signum == k.SIGSTATS {
+			k.failedStatsSignal = false
+		}
+	}
 }


### PR DESCRIPTION
In some times exporter will stuck because of high response time of signals and prometheus will stuck too.
Now we have set a timeout of 1sec for getting response from Keepalived and if there were no response from Keepalived we will proceed with previous data if it has dumped and we will wait for Keepalived to dump stats in another goroutine.