### PR TITLE
Update golangci-lint to 1.24.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := "github.com/cafebazaar/$(PROJECT_NAME)"
 PKG_LIST := $(shell go list ${PKG}/... | grep -v /vendor/)
 GO_FILES := $(shell find . -name '*.go' | grep -v /vendor/ | grep -v _test.go)
 LINTER = golangci-lint
-LINTER_VERSION = v1.23.1
+LINTER_VERSION = v1.24.0
 
 .PHONY: all dep lint build clean
 


### PR DESCRIPTION
This fix Lint CI failure.