### PR TITLE
Set ping packet loss to 100% on failure

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -183,7 +183,7 @@ func (k *KeepalivedCollector) Collect(ch chan<- prometheus.Metric) {
 				pingResult, err := pingVIP(ipAddr)
 				if err != nil {
 					logrus.WithField("VIP", ipAddr).Error("Faild to ping: ", err)
-					continue
+					pingResult.PacketLoss = 100
 				}
 
 				k.newConstMetric(ch, "keepalived_ping_packet_loss", prometheus.GaugeValue, pingResult.PacketLoss, vrrp.Data.IName, intf, strconv.Itoa(vrrp.Data.VRID), ipAddr)


### PR DESCRIPTION
If there were a failure on pinging VIP the ping packet loss metric will become 100% to warn something isn't working!