### PR TITLE
Make ping timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ka.json            | Send SIGJSON and decode JSON file instead of parsing text f
 ka.pid-path        | A path for Keepalived PID, defaults to `/var/run/keepalived.pid`.
 ping               | Export VIP ping status, defaults to `false`.
 ping.count         | ICMP packet counts to be sent, defaults to `1`.
+ping.timeout       | Ping timeout in miliseconds, defaults to `1000`.
 
 **Note:** For `ka.json` option requirement is to have Keepalived compiled with `--enable-json` configure option.
 

--- a/cmd/keepalived-exporter/main.go
+++ b/cmd/keepalived-exporter/main.go
@@ -18,10 +18,11 @@ func main() {
 	keepalivedPID := flag.String("ka.pid-path", "/var/run/keepalived.pid", "A path for Keepalived PID")
 	keepalivedPing := flag.Bool("ping", false, "Export VIP ping status")
 	keepalivedPingCount := flag.Int("ping.count", 1, "ICMP packet counts to be sent")
+	keepalivedPingTimeout := flag.Int("ping.timeout", 1000, "Ping timeout in miliseconds")
 
 	flag.Parse()
 
-	keepalivedCollector := collector.NewKeepalivedCollector(*keepalivedJSON, *keepalivedPing, *keepalivedPID, *keepalivedPingCount)
+	keepalivedCollector := collector.NewKeepalivedCollector(*keepalivedJSON, *keepalivedPing, *keepalivedPID, *keepalivedPingCount, *keepalivedPingTimeout)
 	prometheus.MustRegister(keepalivedCollector)
 
 	http.Handle(*metricsPath, promhttp.Handler())

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -13,16 +13,14 @@ import (
 // KeepalivedCollector implements prometheus.Collector interface and stores required info to collect data
 type KeepalivedCollector struct {
 	sync.Mutex
-	runningSignal     bool
-	failedStatsSignal bool
-	useJSON           bool
-	ping              bool
-	pingCount         int
-	pidPath           string
-	SIGDATA           int
-	SIGJSON           int
-	SIGSTATS          int
-	metrics           map[string]*prometheus.Desc
+	useJSON   bool
+	ping      bool
+	pingCount int
+	pidPath   string
+	SIGDATA   int
+	SIGJSON   int
+	SIGSTATS  int
+	metrics   map[string]*prometheus.Desc
 }
 
 // VRRPStats represents Keepalived stats about VRRP
@@ -76,12 +74,10 @@ type KeepalivedStats struct {
 // NewKeepalivedCollector is creating new instance of KeepalivedCollector
 func NewKeepalivedCollector(useJSON, ping bool, pidPath string, pingCount int) *KeepalivedCollector {
 	kc := &KeepalivedCollector{
-		useJSON:           useJSON,
-		ping:              ping,
-		pingCount:         pingCount,
-		pidPath:           pidPath,
-		runningSignal:     false,
-		failedStatsSignal: false,
+		useJSON:   useJSON,
+		ping:      ping,
+		pingCount: pingCount,
+		pidPath:   pidPath,
 	}
 
 	commonLabels := []string{"iname", "intf", "vrid", "state"}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -13,14 +14,15 @@ import (
 // KeepalivedCollector implements prometheus.Collector interface and stores required info to collect data
 type KeepalivedCollector struct {
 	sync.Mutex
-	useJSON   bool
-	ping      bool
-	pingCount int
-	pidPath   string
-	SIGDATA   int
-	SIGJSON   int
-	SIGSTATS  int
-	metrics   map[string]*prometheus.Desc
+	useJSON     bool
+	ping        bool
+	pingCount   int
+	pingTimeout int
+	pidPath     string
+	SIGDATA     int
+	SIGJSON     int
+	SIGSTATS    int
+	metrics     map[string]*prometheus.Desc
 }
 
 // VRRPStats represents Keepalived stats about VRRP
@@ -72,12 +74,13 @@ type KeepalivedStats struct {
 }
 
 // NewKeepalivedCollector is creating new instance of KeepalivedCollector
-func NewKeepalivedCollector(useJSON, ping bool, pidPath string, pingCount int) *KeepalivedCollector {
+func NewKeepalivedCollector(useJSON, ping bool, pidPath string, pingCount, pingTimeout int) *KeepalivedCollector {
 	kc := &KeepalivedCollector{
-		useJSON:   useJSON,
-		ping:      ping,
-		pingCount: pingCount,
-		pidPath:   pidPath,
+		useJSON:     useJSON,
+		ping:        ping,
+		pingCount:   pingCount,
+		pingTimeout: pingTimeout,
+		pidPath:     pidPath,
 	}
 
 	commonLabels := []string{"iname", "intf", "vrid", "state"}
@@ -211,6 +214,7 @@ func (k *KeepalivedCollector) pingVIP(ipAddr string) (*ping.Statistics, error) {
 	}
 	pinger.SetPrivileged(true)
 	pinger.Count = k.pingCount
+	pinger.Timeout = time.Duration(k.pingTimeout) * time.Millisecond
 	pinger.Run()
 	return pinger.Statistics(), nil
 }

--- a/internal/collector/parser.go
+++ b/internal/collector/parser.go
@@ -56,7 +56,11 @@ func (VRRPData) getIntState(state string) (int, bool) {
 }
 
 func (k *KeepalivedCollector) jsonVrrps() ([]VRRP, error) {
-	k.signalHandler(k.SIGJSON)
+	err := k.signal(k.SIGJSON)
+	if err != nil {
+		logrus.Error("Failed to send JSON signal to keepalived: ", err)
+		return nil, err
+	}
 
 	f, err := os.Open("/tmp/keepalived.json")
 	if err != nil {
@@ -75,7 +79,11 @@ func (k *KeepalivedCollector) jsonVrrps() ([]VRRP, error) {
 }
 
 func (k *KeepalivedCollector) statsVrrps() ([]VRRPStats, error) {
-	k.signalHandler(k.SIGSTATS)
+	err := k.signal(k.SIGSTATS)
+	if err != nil {
+		logrus.Error("Failed to send STATS signal to keepalived: ", err)
+		return nil, err
+	}
 
 	f, err := os.Open("/tmp/keepalived.stats")
 	if err != nil {
@@ -93,8 +101,10 @@ func (k *KeepalivedCollector) statsVrrps() ([]VRRPStats, error) {
 }
 
 func (k *KeepalivedCollector) dataVrrps() ([]VRRPData, error) {
-	if !k.failedStatsSignal {
-		k.signalHandler(k.SIGDATA)
+	err := k.signal(k.SIGDATA)
+	if err != nil {
+		logrus.Error("Failed to send DATA signal to keepalived: ", err)
+		return nil, err
 	}
 
 	f, err := os.Open("/tmp/keepalived.data")


### PR DESCRIPTION
This may cause Keepalived Exporter to be stuck on not replying before another prometheus request.
The default value for ping timeout was 100000sec! It is now configurable via ping.timeout arg.
Related to #8 but not fixing!