### PR TITLE
Fixed bug parsing text data | E.g. no VRID set, no Virtual IP info (keepalived_vrrp_state metric)

### DIFF
--- a/internal/collector/parser.go
+++ b/internal/collector/parser.go
@@ -208,7 +208,10 @@ func (k *KeepalivedCollector) parseVRRPData(i io.Reader) ([]VRRPData, error) {
 
 			s := strings.Split(strings.TrimSpace(l), prop)
 			d.IName = strings.TrimSpace(s[1])
-		} else if strings.HasPrefix(l, "   ") && strings.Contains(l, prop) && d.IName != "" {
+		} else if strings.HasPrefix(l, "   ") && d.IName != "" {
+			if !strings.Contains(l, prop) {
+				continue
+			}
 			s := strings.Split(strings.TrimSpace(l), prop)
 			key := strings.TrimSpace(s[0])
 			val := strings.TrimSpace(s[1])


### PR DESCRIPTION
Keepalived data file can contain following info
```
 VRRP Instance = server.domain.com
   VRRP Version = 2
   State = MASTER
   ...
   Interface = ens33
   VRRP interface tracking disabled
```
The last citated line does not look like `PROPERTY = VALUE`, so the `parseVRRPData`
function stops iterating properties and so does not gather some info: `vrid`
and `Virtual IP` info, for example.

Let's just skip such lines.