### PR TITLE
fix: parse Virtual IP more than 5 chars

### DIFF
--- a/internal/collector/parser.go
+++ b/internal/collector/parser.go
@@ -430,7 +430,7 @@ func (k *KeepalivedCollector) parseStats(i io.Reader) ([]VRRPStats, error) {
 
 func parseVIP(vip string) (string, string, bool) {
 	args := strings.Split(vip, " ")
-	if len(args) != 5 {
+	if len(args) < 3 {
 		logrus.WithField("VIP", vip).Error("Failed to parse VIP from keepalived data")
 		return "", "", false
 	}

--- a/internal/collector/parser_test.go
+++ b/internal/collector/parser_test.go
@@ -329,16 +329,24 @@ func TestV215ParseStats(t *testing.T) {
 }
 
 func TestParseVIP(t *testing.T) {
-	vip := "192.168.2.2 dev ens192 scope global"
+	vips := []string{"192.168.2.2 dev ens192 scope global", "192.168.2.2 dev ens192 scope global set"}
 	excpectedIP := "192.168.2.2"
 	excpectedIntf := "ens192"
 
-	ip, intf, ok := parseVIP(vip)
-	if !ok {
-		t.Fail()
+	for _, vip := range vips {
+		ip, intf, ok := parseVIP(vip)
+		if !ok {
+			t.Fail()
+		}
+
+		if ip != excpectedIP || intf != excpectedIntf {
+			t.Fail()
+		}
 	}
 
-	if ip != excpectedIP || intf != excpectedIntf {
+	badVIP := "192.168.2.2 dev"
+	ip, intf, ok := parseVIP(badVIP)
+	if ok || ip != "" || intf != "" {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
There maybe two `Virtual IP` format in in keepalived.data that in both we just need index 0 and 2 for ip and interface and we could ignore others.