### PR TITLE
build: Add version flag to show metadata info

### DIFF
--- a/cmd/keepalived-exporter/main.go
+++ b/cmd/keepalived-exporter/main.go
@@ -11,14 +11,30 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// nolint: gochecknoglobals // since these are build time variables
+var (
+	commit    string
+	version   string
+	buildTime string
+)
+
 func main() {
 	listenAddr := flag.String("web.listen-address", ":9165", "Address to listen on for web interface and telemetry.")
 	metricsPath := flag.String("web.telemetry-path", "/metrics", "A path under which to expose metrics.")
 	keepalivedJSON := flag.Bool("ka.json", false, "Send SIGJSON and decode JSON file instead of parsing text files.")
 	keepalivedPID := flag.String("ka.pid-path", "/var/run/keepalived.pid", "A path for Keepalived PID")
 	keepalivedCheckScript := flag.String("cs", "", "Health Cehck script path to be execute for each VIP")
+	versionFlag := flag.Bool("version", false, "Show the current keepalived exporter version")
 
 	flag.Parse()
+
+	if *versionFlag {
+		logrus.WithFields(logrus.Fields{
+			"commit": commit, "version": version, "build_time": buildTime,
+		}).Info("Keepalived Exporter")
+
+		return
+	}
 
 	keepalivedCollector := collector.NewKeepalivedCollector(*keepalivedJSON, *keepalivedPID, *keepalivedCheckScript)
 	prometheus.MustRegister(keepalivedCollector)


### PR DESCRIPTION
Inject version, commit, and buildTime metadata when building.

Closes #46.