### PR TITLE
fix: parse signum with json.Unmarshal in host mode

### DIFF
--- a/internal/types/host/keepalived_host_collector_host.go
+++ b/internal/types/host/keepalived_host_collector_host.go
@@ -115,12 +115,7 @@ func (k *KeepalivedHostCollectorHost) sigNum(sigString string) syscall.Signal {
 		logrus.WithFields(logrus.Fields{"signal": sigString, "stderr": stderr.String()}).WithError(err).Fatal("Error getting signum")
 	}
 
-	signum, err := strconv.ParseInt(stdout.String(), 10, 32)
-	if err != nil {
-		logrus.WithFields(logrus.Fields{"signal": sigString, "signum": stdout.String()}).WithError(err).Fatal("Error parsing signum result")
-	}
-
-	return syscall.Signal(signum)
+	return syscall.Signal(parseSigNum(stdout, sigString))
 }
 
 func (k *KeepalivedHostCollectorHost) JSONVrrps() ([]collector.VRRP, error) {

--- a/internal/types/host/utils.go
+++ b/internal/types/host/utils.go
@@ -1,0 +1,18 @@
+package host
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/sirupsen/logrus"
+)
+
+func parseSigNum(sigNum bytes.Buffer, sigString string) int64 {
+	var signum int64
+	err := json.Unmarshal(sigNum.Bytes(), &signum)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{"signal": sigString, "signum": sigNum.String()}).WithError(err).Fatal("Error parsing signum result")
+	}
+
+	return signum
+}

--- a/internal/types/host/utils_test.go
+++ b/internal/types/host/utils_test.go
@@ -1,0 +1,15 @@
+package host
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestParseSigNum(t *testing.T) {
+	signum := bytes.NewBufferString("10\n")
+	sigNumInt := parseSigNum(*signum, "DATA")
+
+	if sigNumInt != 10 {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Because of \n in output, this could be done with json.Unmarshal func

Fixes: #59 